### PR TITLE
fixed multi-insert keys in related though event

### DIFF
--- a/src/Traits/RelatedThrough/SetRelatedThroughRepositoryEvent.php
+++ b/src/Traits/RelatedThrough/SetRelatedThroughRepositoryEvent.php
@@ -89,7 +89,7 @@ class SetRelatedThroughRepositoryEvent extends RepositoryEvent
                 array_map(fn($idToInsert) => [
                     $this->ownerColumn => $ownerId,
                     $this->ownedColumn => $idToInsert,
-                ], $idsToInsert)
+                ], array_values($idsToInsert))
             );
         }
         return count($idsToInsert) + count($idsToDelete);


### PR DESCRIPTION
Saving M:N relations via `SetRelatedThroughRepositoryEvent` produce TypeError `[Nette\Database\SqlPreprocessor::delimite]: Argument #1 ($name) must be of type string, int given, called in ...`.

The same bug described here (CZ): https://forum.nette.org/cs/34323-vstupni-data-pro-nette-database-multi-insert
