### PR TITLE
Table name prefix in order columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Table name prefix in order columns
 
 ## [0.7.0] - 2025-12-05
 ### Added

--- a/src/Traits/DefaultOrder/DefaultOrderBehavior.php
+++ b/src/Traits/DefaultOrder/DefaultOrderBehavior.php
@@ -7,6 +7,8 @@ use Efabrica\NetteRepository\Traits\RepositoryBehavior;
 
 class DefaultOrderBehavior extends RepositoryBehavior
 {
+    private const COLUMNS_PATTERN = '/(?<!\.)\b(?!ASC\b)(?!DESC\b)([A-Za-z_][A-Za-z0-9_]*)\b(?!\s*\.)/i';
+
     private string $columns;
 
     private array $params;
@@ -23,7 +25,10 @@ class DefaultOrderBehavior extends RepositoryBehavior
     public function apply(QueryInterface $query): void
     {
         if ($query->getOrder() === []) {
-            $query->order($this->columns, ...$this->params);
+            $query->order(
+                preg_replace(self::COLUMNS_PATTERN, $query->getName() . '.$1', $this->columns),
+                ...$this->params
+            );
         }
     }
 }

--- a/src/Traits/Sorting/SortingEventSubscriber.php
+++ b/src/Traits/Sorting/SortingEventSubscriber.php
@@ -23,8 +23,9 @@ class SortingEventSubscriber extends EventSubscriber implements RelatedEventSubs
     public function onInsert(InsertRepositoryEvent $event): InsertEventResponse
     {
         $behavior = $event->getBehavior(SortingBehavior::class);
+        $query = $event->getRepository()->query();
         $sortingColumn = $behavior->getColumn();
-        $max = $event->getRepository()->query()->max($sortingColumn);
+        $max = $query->max($query->getName() . '.' . $sortingColumn);
         foreach ($event->getEntities() as $entity) {
             if (!isset($entity->$sortingColumn)) {
                 $max += $behavior->getStep();


### PR DESCRIPTION
Column 'sorting' in order clause may be ambiguous if joins presents.